### PR TITLE
Add CGO compliation toolchain related to ARM architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN gzip -dc "${OSX_CROSS_PATH}/tarballs/libtool-${LIBTOOL_VERSION}.tar.gz" | ta
 # Making the final image with goreleaser and osxcross
 FROM --platform=linux/arm64/v8 osx-cross-base AS final-arm64
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -qq && apt-get install -y -q --no-install-recommends \
+RUN apt-get update -qq && apt-get install -y -q --no-install-recommends --fix-missing \
     libltdl-dev \
     gcc-multilib-i686-linux-gnu \
     g++-multilib-i686-linux-gnu \
@@ -92,19 +92,29 @@ RUN apt-get update -qq && apt-get install -y -q --no-install-recommends \
     g++-multilib-x86-64-linux-gnu \
     gcc-mingw-w64 \
     g++-mingw-w64 \
+    gcc-arm-linux-gnueabihf \ 
+    g++-arm-linux-gnueabihf \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu \
     parallel \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 FROM --platform=linux/amd64 osx-cross-base AS final-amd64
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -qq && apt-get install -y -q --no-install-recommends \
+RUN apt-get update -qq && apt-get install -y -q --no-install-recommends --fix-missing \
     libltdl-dev \
     gcc-multilib \
     g++-multilib \
     gcc-mingw-w64 \
     g++-mingw-w64 \
+    gcc-arm-linux-gnueabihf \ 
+    g++-arm-linux-gnueabihf \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu \
     parallel \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ 
 
 ###################
 # multiarch build stage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # vxbuild-cross
+
 Cross compile build system to assemble VXMonitor project.
 
 [This repo](https://github.com/vxcontrol/vxbuild-cross) contains a Dockerfile for building an image which is used to cross compile golang. It includes the MinGW compiler for windows, and an OSX SDK via [osxcross](https://github.com/tpoechtrager/osxcross).
@@ -8,9 +9,11 @@ These images are available from https://hub.docker.com/r/vxcontrol/vxbuild-cross
 **Important**: these images was builded with OSX SDK 10.15 to make it with 10.10 or 10.11 SDKs, please, use custom builds from Building part of Readme.
 
 ## Fork
+
 This project based on original repository by [docker/golang-cross](https://github.com/docker/golang-cross).
 
 ## Default arguments
+
 ```Dockerfile
 # Golang docker image options
 ARG GO_IMAGE=buster
@@ -37,16 +40,19 @@ ARG OSX_CROSS_REQUIREMENTS="libssl-dev libxml2-dev zlib1g-dev"
 ## Building
 
 ### The simple way
+
 ```bash
 docker build -t local/vxbuild-cross:latest .
 ```
 
 ### Build with state cleanup
+
 ```bash
 docker build --no-cache -t local/vxbuild-cross:latest .
 ```
 
 ### Use arguments to choose golang version
+
 ```bash
 docker build \
  --build-arg GO_IMAGE="stretch" \
@@ -55,6 +61,7 @@ docker build \
 ```
 
 ### Use arguments to build multi-platform images
+
 ```bash
 docker buildx build \
  --platform linux/amd64,linux/arm64/v8 \
@@ -62,6 +69,7 @@ docker buildx build \
 ```
 
 ### Use arguments to choose MacOS SDK 10.10
+
 ```bash
 docker build \
  --build-arg LIBTOOL_VERSION="2.4.6_1" \
@@ -76,6 +84,7 @@ docker build \
 ```
 
 ### Use arguments to choose MacOS SDK 10.11
+
 ```bash
 docker build \
  --build-arg LIBTOOL_VERSION="2.4.6_1" \
@@ -90,6 +99,7 @@ docker build \
 ```
 
 ### Use arguments to choose MacOS SDK 10.15 (by default)
+
 ```bash
 docker build \
  --build-arg LIBTOOL_VERSION="2.4.6_3" \
@@ -107,36 +117,39 @@ docker build \
 
 ### Check golang version
 
-* `docker run --rm vxcontrol/vxbuild-cross go version`
+- `docker run --rm vxcontrol/vxbuild-cross go version`
 
 ### Simple attach to container
 
-* `docker run --rm -it vxcontrol/vxbuild-cross /bin/bash`
-* `docker run --rm -v /host/gopath:/go -it vxcontrol/vxbuild-cross /bin/bash`
+- `docker run --rm -it vxcontrol/vxbuild-cross /bin/bash`
+- `docker run --rm -v /host/gopath:/go -it vxcontrol/vxbuild-cross /bin/bash`
 
 ### Cross compile simple Go project (docker container inside)
 
-* `GOOS=linux GOARCH=amd64 go build`
-* `GOOS=linux GOARCH=386 go build`
-* `GOOS=darwin GOARCH=amd64 go build`
-* `GOOS=darwin GOARCH=386 go build`
-* `GOOS=windows GOARCH=amd64 go build`
-* `GOOS=windows GOARCH=386 go build`
+- `GOOS=linux GOARCH=amd64 go build`
+- `GOOS=linux GOARCH=386 go build`
+- `GOOS=linux GOARCH=arm GOARM=7 go build`
+- `GOOS=linux GOARCH=arm64 go build`
+- `GOOS=darwin GOARCH=amd64 go build`
+- `GOOS=windows GOARCH=amd64 go build`
+- `GOOS=windows GOARCH=386 go build`
 
 ### Cross compile Go project with cgo on linux/amd64 (docker container inside)
 
-* `GOOS=linux GOARCH=amd64 CC=gcc CXX=g++ CGO_ENABLED=1 go build`
-* `GOOS=linux GOARCH=386 CC=gcc CXX=g++ CGO_ENABLED=1 go build`
-* `GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ CGO_ENABLED=1 go build`
-* `GOOS=darwin GOARCH=386 CC=o32-clang CXX=o32-clang++ CGO_ENABLED=1 go build`
-* `GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CGO_ENABLED=1 go build`
-* `GOOS=windows GOARCH=386 CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ CGO_ENABLED=1 go build`
+- `GOOS=linux GOARCH=amd64 CC=gcc CXX=g++ CGO_ENABLED=1 go build`
+- `GOOS=linux GOARCH=386 CC=gcc CXX=g++ CGO_ENABLED=1 go build`
+- `GOOS=linux GOARCH=arm GOARM=7 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ CGO_ENABLED=1 go build`
+- `GOOS=linux GOARCH=arm64  CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ CGO_ENABLED=1 go build`
+- `GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ CGO_ENABLED=1 go build`
+- `GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CGO_ENABLED=1 go build`
+- `GOOS=windows GOARCH=386 CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ CGO_ENABLED=1 go build`
 
 ### Cross compile Go project with cgo on linux/arm64 (docker container inside)
 
-* `GOOS=linux GOARCH=amd64 CC=x86_64-linux-gnu-gcc CXX=x86_64-linux-gnu-g++ CGO_ENABLED=1 go build`
-* `GOOS=linux GOARCH=386 CC=i686-linux-gnu-gcc CXX=i686-linux-gnu-g++ CGO_ENABLED=1 go build`
-* `GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ CGO_ENABLED=1 go build`
-* `GOOS=darwin GOARCH=386 CC=o32-clang CXX=o32-clang++ CGO_ENABLED=1 go build`
-* `GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CGO_ENABLED=1 go build`
-* `GOOS=windows GOARCH=386 CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ CGO_ENABLED=1 go build`
+- `GOOS=linux GOARCH=amd64 CC=x86_64-linux-gnu-gcc CXX=x86_64-linux-gnu-g++ CGO_ENABLED=1 go build`
+- `GOOS=linux GOARCH=386 CC=i686-linux-gnu-gcc CXX=i686-linux-gnu-g++ CGO_ENABLED=1 go build`
+- `GOOS=linux GOARCH=arm GOARM=7 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ CGO_ENABLED=1 go build`
+- `GOOS=linux GOARCH=arm64  CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ CGO_ENABLED=1 go build`
+- `GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ CGO_ENABLED=1 go build`
+- `GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CGO_ENABLED=1 go build`
+- `GOOS=windows GOARCH=386 CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ CGO_ENABLED=1 go build`


### PR DESCRIPTION
+ Add CGO compliation toolchain related to ARM architechture in Dockerfile

+ Update README.md

    - `darwin/386` architecture is indeed not supported from Go 1.15, so delete the relevant content
    - add content related to ARM architecture
